### PR TITLE
Change default output size add ability to have custom output size Closes #1

### DIFF
--- a/Blake3Core.Tests/Constructors.cs
+++ b/Blake3Core.Tests/Constructors.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 using Xunit;
 
 namespace Blake3Core.Tests

--- a/Blake3Core.Tests/Correctness.cs
+++ b/Blake3Core.Tests/Correctness.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection.Metadata.Ecma335;
 using System.Text;
 using Xunit;
 
@@ -10,6 +9,7 @@ namespace Blake3Core.Tests
     public class Correctness
     {
         static Dictionary<int, IEnumerable<byte>> _inputBytes = new Dictionary<int, IEnumerable<byte>>();
+        private const int _defaultOutputByteSize = 32;
 
         static IEnumerable<byte> GetInputBytes(int length)
         {
@@ -20,11 +20,16 @@ namespace Blake3Core.Tests
 
         void VerifyAllAtOnce(Func<Blake3> create, int inputLength, string expectedHash)
         {
+            VerifyAllAtOnce(create, inputLength, expectedHash, _defaultOutputByteSize);
+        }
+
+        void VerifyAllAtOnce(Func<Blake3> create, int inputLength, string expectedHash, int byteOutputSize)
+        {
             var hasher = create();
             var input = GetInputBytes(inputLength).ToArray();
             var hash = hasher.ComputeHash(input);
 
-            Assert.Equal(64, hash.Length);
+            Assert.Equal(byteOutputSize, hash.Length);
             Assert.Equal(expectedHash, hasher.GetExtendedOutput()
                                              .Take(expectedHash.Length / 2)
                                              .ToArray()
@@ -39,7 +44,7 @@ namespace Blake3Core.Tests
                 hasher.TransformBlock(input, i, 1, null, 0);
             hasher.TransformFinalBlock(input, 0, 0);
 
-            Assert.Equal(64, hasher.Hash.Length);
+            Assert.Equal(_defaultOutputByteSize, hasher.Hash.Length);
             Assert.Equal(expectedHash, hasher.GetExtendedOutput()
                                              .Take(expectedHash.Length / 2)
                                              .ToArray()
@@ -53,6 +58,18 @@ namespace Blake3Core.Tests
             VerifyAllAtOnce(() => new Blake3(),
                             testVector.InputLength,
                             testVector.Hash);
+        }
+
+        [Theory]
+        [ClassData(typeof(TestVectors))]
+        void VerifyHash512b(TestVector testVector)
+        {
+            var bitLength = 512;
+
+            VerifyAllAtOnce(() => new Blake3(bitLength),
+                            testVector.InputLength,
+                            testVector.Hash,
+                            bitLength / 8);
         }
 
         [Theory]

--- a/Blake3Core.Tests/Correctness.cs
+++ b/Blake3Core.Tests/Correctness.cs
@@ -9,7 +9,7 @@ namespace Blake3Core.Tests
     public class Correctness
     {
         static Dictionary<int, IEnumerable<byte>> _inputBytes = new Dictionary<int, IEnumerable<byte>>();
-        private const int _defaultOutputByteSize = 32;
+        const int _defaultOutputByteSize = 32;
 
         static IEnumerable<byte> GetInputBytes(int length)
         {

--- a/Blake3Core/Blake3.cs
+++ b/Blake3Core/Blake3.cs
@@ -53,12 +53,7 @@ namespace Blake3Core
         protected private static Blake3 Create(Flag defaultFlag, ReadOnlySpan<uint> key, int? outputSizeInBits)
             => new Blake3(defaultFlag, key, outputSizeInBits);
 
-        public Blake3()
-            : this(Flag.None, IV, HashSizeInBits)
-        {
-        }
-
-        public Blake3(int hashSizeInBits)
+        public Blake3(int hashSizeInBits = HashSizeInBits)
             : this(Flag.None, IV, hashSizeInBits)
         {
         }

--- a/Blake3Core/Blake3DerivedKey.cs
+++ b/Blake3Core/Blake3DerivedKey.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Blake3Core
@@ -8,7 +6,7 @@ namespace Blake3Core
     public class Blake3DerivedKey : Blake3
     {
         public Blake3DerivedKey(byte[] context)
-            : base(Flag.DeriveKeyMaterial, DeriveKey(context))
+            : base(Flag.DeriveKeyMaterial, DeriveKey(context), HashSizeInBits)
         {
         }
 
@@ -27,15 +25,15 @@ namespace Blake3Core
         {
         }
 
-        static byte [] ComputeHash(Flag flag, ReadOnlySpan<uint> key, byte[] message)
+        static byte [] ComputeHash(Flag flag, ReadOnlySpan<uint> key, int outputSizeInBits, byte[] message)
         {
-            using (var hashAlgorithm = Blake3.Create(flag, key))
+            using (var hashAlgorithm = Blake3.Create(flag, key, outputSizeInBits))
                 return hashAlgorithm.ComputeHash(message);
         }
 
         static byte[] DeriveKey(byte[] context)
         {
-            var keyContext = ComputeHash(Flag.DeriveKeyContext, IV, context);
+            var keyContext = ComputeHash(Flag.DeriveKeyContext, IV, HashSizeInBits, context);
             return keyContext.AsSpan().Slice(0, 8 * sizeof(uint)).ToArray();
         }
     }

--- a/Blake3Core/Blake3Keyed.cs
+++ b/Blake3Core/Blake3Keyed.cs
@@ -1,19 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Text;
-
-namespace Blake3Core
+﻿namespace Blake3Core
 {
     public class Blake3Keyed : Blake3
     {
         public Blake3Keyed(byte[] key)
-            : base(Flag.KeyedHash, key)
+            : base(Flag.KeyedHash, key, HashSizeInBits)
         {
         }
 
         public Blake3Keyed(uint[] key)
-            : base(Flag.KeyedHash, key)
+            : base(Flag.KeyedHash, key, HashSizeInBits)
         {
         }
     }


### PR DESCRIPTION
I've changed the default output size from 512 to 256 bit per BLAKE3 spec.

I was unsure how to implement support for custom output length, I chose to go about in bits, I don't know if it would be better in bytes? I chose bits as that's usually the number hash algorithms advertise and make themselves known by.

This is just a proposal, please let me know if you'd like anything changed. 